### PR TITLE
Standardization of all the icon sizes to 16px. 

### DIFF
--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -44,6 +44,12 @@ body, html {
   min-height: 100vh;
 }
 
+/* Standardization of icon sizes to 16px */	
+.gwt-Tree img, .ode-Icon img, .ode-Icon-selected img {	
+  width: 16px;	
+  height: 16px;	
+}
+
 /* Needed for Safari to position comments correctly */
 body.blocklyMinimalBody {
   min-width: auto;


### PR DESCRIPTION
The added code standardizes all icon sizes to 16px, relieving extension makers from concerns about their extension's icon size.

The problem that this PR solves is that a few extension icons have larger sizes than 16x16px and this PR standardizes all the icons across the app inventor to 16px.

Example of this issue : 
![LargeIcon](https://github.com/Venkata-Sai-Vishwanath-robo/appinventor-sources/assets/116882464/845e3e95-3edf-4624-aa43-756de985e7bb)

